### PR TITLE
add python dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:latest
 
 WORKDIR /build
 
-ENV BUILD_PACKAGES "build-essential git curl zlib1g-dev"
+ENV BUILD_PACKAGES "build-essential git curl zlib1g-dev python"
 RUN apt-get update -y && \
     apt-get install $BUILD_PACKAGES -y && \
     git clone https://github.com/edenhill/kafkacat.git && \


### PR DESCRIPTION
compilation fails without python

> checking for python (by command)... failed (disable)
> disabling linker-script since python is not available
