### PR TITLE
Fix build on Debian new stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
-FROM debian:jessie
+FROM debian:stable-20170620
 
 WORKDIR /build
 
-ENV BUILD_PACKAGES "build-essential git curl zlib1g-dev python"
+ENV BUILD_PACKAGES "build-essential git curl ca-certificates zlib1g-dev python"
 RUN apt-get update -y && \
-    apt-get install $BUILD_PACKAGES -y && \
+    apt-get install -y --no-install-recommends $BUILD_PACKAGES && \
     git clone https://github.com/edenhill/kafkacat.git && \
     cd kafkacat && \
     ./bootstrap.sh && \
     make install && \
     cd .. && rm -rf kafkacat && \
-    AUTO_ADDED_PACKAGES=`apt-mark showauto` && \
-    apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES && \
+    apt-get remove --purge -y $BUILD_PACKAGES && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENTRYPOINT ["kafkacat"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:jessie
 
 WORKDIR /build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 FROM debian:stable-20170620
 
-WORKDIR /build
-
-ENV BUILD_PACKAGES "build-essential git curl ca-certificates zlib1g-dev python"
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends $BUILD_PACKAGES && \
-    git clone https://github.com/edenhill/kafkacat.git && \
-    cd kafkacat && \
-    ./bootstrap.sh && \
-    make install && \
-    cd .. && rm -rf kafkacat && \
-    apt-get remove --purge -y $BUILD_PACKAGES && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN buildDeps='curl ca-certificates build-essential zlib1g-dev python cmake'; \
+  set -ex; \
+  apt-get update && apt-get install -y $buildDeps --no-install-recommends; \
+  rm -rf /var/lib/apt/lists/*; \
+  \
+  mkdir /usr/src/kafkacat; \
+  curl -SLs "https://github.com/edenhill/kafkacat/archive/master.tar.gz" | tar -xzf - --strip-components=1 -C /usr/src/kafkacat; \
+  cd /usr/src/kafkacat; \
+  ./bootstrap.sh; \
+  mv ./kafkacat /usr/local/bin/; \
+  \
+  rm -rf /usr/src/kafkacat/tmp-bootstrap; \
+  apt-get purge -y --auto-remove $buildDeps
 
 ENTRYPOINT ["kafkacat"]


### PR DESCRIPTION
First commit does fix the build, but I also tried to use the new stable. However with:
```
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
0c5e03aa103d        2 minutes ago       /bin/sh -c buildDeps='curl ca-certificates...   7.74MB              
9c50851e771d        2 weeks ago         /bin/sh -c #(nop)  CMD ["bash"]                 0B                  
<missing>           2 weeks ago         /bin/sh -c #(nop) ADD file:9c9710c289d7b17...   100MB               
```
the build layer is twice the size of your image:
```
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
3e2bfb46fec8        13 months ago       /bin/sh -c #(nop) ENTRYPOINT ["kafkacat"]       0B                  
<missing>           13 months ago       /bin/sh -c apt-get update -y &&     apt-ge...   3.69MB              
<missing>           13 months ago       /bin/sh -c #(nop) ENV BUILD_PACKAGES=build...   0B                  
<missing>           13 months ago       /bin/sh -c #(nop) WORKDIR /build                0B                  
<missing>           14 months ago       /bin/sh -c #(nop) CMD ["/bin/bash"]             0B                  
<missing>           14 months ago       /bin/sh -c #(nop) ADD file:dc2eddd5d35b9d6...   125MB
```
but as seen in https://github.com/solsson/docker-kafkacat/commit/bfacff266698d70f1971f63efd7df0d0f570cdad the cleanup completely failed on debian:stretch, which is why I tried a different strategy.